### PR TITLE
feat: support agents.md as default guidelines path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `boost-for-kiro-ide` will be documented in this file.
 
+## [2.0.4] - 2026-03-03
+
+### Added
+
+- Made `guidelinesPath()` configurable via `boost.agents.kiro.guidelines_path` config key
+- Added "Custom Guidelines Path" section to README documenting the new configuration option
+
+### Changed
+
+- Default guidelines path remains `.kiro/steering/laravel-boost.md` (Kiro's native steering convention)
+- Teams using multiple AI IDEs can now opt in to `AGENTS.md` or any custom path via configuration
+
+### Credits
+
+- Thanks to [@FSElias](https://github.com/FSElias) for the initial implementation in [#6](https://github.com/jotafurtado/boost-for-kiro-ide/pull/6)
+
 ## [2.0.3] - 2026-02-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ After installation, Kiro will have access to all Laravel Boost MCP tools, includ
 - **Tinker**: Execute arbitrary code in the application context
 - And much more...
 
+## Custom Guidelines Path
+
+By default, Kiro's AI guidelines are stored at `.kiro/steering/laravel-boost.md`, following Kiro's native steering convention. This allows you to take advantage of Kiro-specific features like frontmatter-based inclusion rules and file references.
+
+If your team uses multiple AI-powered IDEs and prefers a shared guidelines file (e.g., `AGENTS.md`), you can customize the path via configuration:
+
+```php
+// config/boost.php
+'agents' => [
+    'kiro' => [
+        'guidelines_path' => 'AGENTS.md',
+    ],
+],
+```
+
 ## Updating Guidelines
 
 To keep your AI guidelines up to date with the latest versions of installed Laravel ecosystem packages, run:

--- a/src/CodeEnvironment/Kiro.php
+++ b/src/CodeEnvironment/Kiro.php
@@ -64,7 +64,7 @@ class Kiro extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSki
 
     public function guidelinesPath(): string
     {
-        return '.kiro/steering/laravel-boost.md';
+        return config('boost.agents.kiro.guidelines_path', 'AGENTS.md');
     }
 
     public function skillsPath(): string

--- a/src/CodeEnvironment/Kiro.php
+++ b/src/CodeEnvironment/Kiro.php
@@ -64,7 +64,7 @@ class Kiro extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSki
 
     public function guidelinesPath(): string
     {
-        return config('boost.agents.kiro.guidelines_path', 'AGENTS.md');
+        return config('boost.agents.kiro.guidelines_path', '.kiro/steering/laravel-boost.md');
     }
 
     public function skillsPath(): string


### PR DESCRIPTION
I found that Kiro IDE is loading both the steering files AGENTS.md and .kiro/steering/laravel-boost.md when another agent is installed that uses AGENTS.md.

Update guidelinesPath() to default to AGENTS.md instead of .kiro/steering/laravel-boost.md, adopting the agents.md convention.

The path is now configurable via boost.agents.kiro.guidelines_path config key, allowing teams to customize the location.

Refs: kirodotdev/Kiro#2410